### PR TITLE
Feature/20 add courses schedules

### DIFF
--- a/app/(main)/courses/[id]/@schedules/loading.tsx
+++ b/app/(main)/courses/[id]/@schedules/loading.tsx
@@ -3,11 +3,11 @@ import { SectionLabelBox } from '@/components/section-label';
 
 export default function Loading() {
   return (
-    <main className="flex flex-col gap-[10px] pb-[10px] opacity-30">
+    <section className="flex flex-col gap-[10px] pb-[10px] opacity-30">
       <SectionLabelBox className="mt-[20px] h-[20px] w-[80px] flex-initial animate-pulse rounded-sm bg-neutral p-0" />
       {Array.from({ length: 4 }, (_, i) => (
         <ScheduleBox key={i} className="h-[122px] animate-pulse bg-border" />
       ))}
-    </main>
+    </section>
   );
 }

--- a/app/(main)/courses/[id]/@schedules/loading.tsx
+++ b/app/(main)/courses/[id]/@schedules/loading.tsx
@@ -1,0 +1,13 @@
+import { ScheduleBox } from '@/components/schedule/schedule';
+import { SectionLabelBox } from '@/components/section-label';
+
+export default function Loading() {
+  return (
+    <main className="flex flex-col gap-[10px] pb-[10px] opacity-30">
+      <SectionLabelBox className="mt-[20px] h-[20px] w-[80px] flex-initial animate-pulse rounded-sm bg-neutral p-0" />
+      {Array.from({ length: 4 }, (_, i) => (
+        <ScheduleBox key={i} className="h-[122px] animate-pulse bg-border" />
+      ))}
+    </main>
+  );
+}

--- a/app/(main)/courses/[id]/@schedules/page.tsx
+++ b/app/(main)/courses/[id]/@schedules/page.tsx
@@ -1,28 +1,29 @@
 import PaginatedSchedules from '@/app/(main)/courses/[id]/@schedules/paginated-schedules';
 import SectionLabel from '@/components/section-label';
-import { CourseSchedulesRouteParams, CourseSchedulesRouteResponse } from '@/types/api/course/schedules';
+import {
+  CourseSchedulesRouteParams,
+  CourseSchedulesRouteResponse,
+} from '@/types/api/course/schedules';
 import fakeFetch from '@/utils/fake-fetch';
 
-
-export default async function Page({
-  params,
-}: {
-  params: { id: string };
-}) {
+export default async function Page({ params }: { params: { id: string } }) {
   const initialPaginatedSchedules = await fakeFetch<
-  CourseSchedulesRouteResponse,
-  CourseSchedulesRouteParams
->({
-  endpoint: '/course/schedules',
-  params: { itemsPerPage: 4, page: 0, courseId: params.id },
-  timeout: 2000,
-});
+    CourseSchedulesRouteResponse,
+    CourseSchedulesRouteParams
+  >({
+    endpoint: '/course/schedules',
+    params: { itemsPerPage: 4, page: 0, courseId: params.id },
+    timeout: 2000,
+  });
 
   return (
     <section className="mx-auto flex flex-col gap-[10px] p-[10px] max-width">
       <SectionLabel info="Sessions">Courses in Session</SectionLabel>
       {/** Use a bunch of schedules */}
-      <PaginatedSchedules courseId={params.id} initialPaginatedItems={initialPaginatedSchedules}/>
+      <PaginatedSchedules
+        courseId={params.id}
+        initialPaginatedItems={initialPaginatedSchedules}
+      />
     </section>
   );
 }

--- a/app/(main)/courses/[id]/@schedules/page.tsx
+++ b/app/(main)/courses/[id]/@schedules/page.tsx
@@ -1,10 +1,28 @@
+import PaginatedSchedules from '@/app/(main)/courses/[id]/@schedules/paginated-schedules';
 import SectionLabel from '@/components/section-label';
+import { CourseSchedulesRouteParams, CourseSchedulesRouteResponse } from '@/types/api/course/schedules';
+import fakeFetch from '@/utils/fake-fetch';
 
-export default function Page() {
+
+export default async function Page({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const initialPaginatedSchedules = await fakeFetch<
+  CourseSchedulesRouteResponse,
+  CourseSchedulesRouteParams
+>({
+  endpoint: '/course/schedules',
+  params: { itemsPerPage: 4, page: 0, courseId: params.id },
+  timeout: 2000,
+});
+
   return (
     <main className="mx-auto flex flex-col gap-[10px] p-[10px] max-width">
       <SectionLabel info="Sessions">Courses in Session</SectionLabel>
       {/** Use a bunch of schedules */}
+      <PaginatedSchedules courseId={params.id} initialPaginatedItems={initialPaginatedSchedules}/>
     </main>
   );
 }

--- a/app/(main)/courses/[id]/@schedules/page.tsx
+++ b/app/(main)/courses/[id]/@schedules/page.tsx
@@ -1,5 +1,4 @@
 import PaginatedSchedules from '@/app/(main)/courses/[id]/@schedules/paginated-schedules';
-import SectionLabel from '@/components/section-label';
 import {
   CourseSchedulesRouteParams,
   CourseSchedulesRouteResponse,
@@ -17,13 +16,9 @@ export default async function Page({ params }: { params: { id: string } }) {
   });
 
   return (
-    <section className="mx-auto flex flex-col gap-[10px] p-[10px] max-width">
-      <SectionLabel info="Sessions">Courses in Session</SectionLabel>
-      {/** Use a bunch of schedules */}
-      <PaginatedSchedules
-        courseId={params.id}
-        initialPaginatedItems={initialPaginatedSchedules}
-      />
-    </section>
+    <PaginatedSchedules
+      courseId={params.id}
+      initialPaginatedItems={initialPaginatedSchedules}
+    />
   );
 }

--- a/app/(main)/courses/[id]/@schedules/paginated-schedules.tsx
+++ b/app/(main)/courses/[id]/@schedules/paginated-schedules.tsx
@@ -6,7 +6,10 @@ import Button from '@/components/button';
 import Schedule from '@/components/schedule/schedule';
 import usePaginatedItems from '@/hooks/use-paginated-items';
 import useWrappedRequest from '@/hooks/use-wrapped-request';
-import { CourseSchedulesRouteParams, CourseSchedulesRouteResponse } from '@/types/api/course/schedules';
+import {
+  CourseSchedulesRouteParams,
+  CourseSchedulesRouteResponse,
+} from '@/types/api/course/schedules';
 import fakeFetch from '@/utils/fake-fetch';
 
 const PaginatedSchedules: React.FC<{
@@ -30,23 +33,14 @@ const PaginatedSchedules: React.FC<{
   return (
     <>
       {paginatedItems?.items.map((schedule, i) => {
-        const {
-          days,
-          classType,
-          courseId,
-          name,
-          section,
-          ...rest
-        } = schedule;
+        const { days, classType, courseId, name, section, ...rest } = schedule;
         return (
           <Schedule
             key={i}
             heading={`${name}`}
             subheading={`Section ${section}`}
             days={new Set(days)}
-            additionalInfo={[
-              classType,
-            ]}
+            additionalInfo={[classType]}
             {...rest}
             section={section}
           />

--- a/app/(main)/courses/[id]/@schedules/paginated-schedules.tsx
+++ b/app/(main)/courses/[id]/@schedules/paginated-schedules.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import Button from '@/components/button';
 import Schedule from '@/components/schedule/schedule';
+import SectionLabel from '@/components/section-label';
 import usePaginatedItems from '@/hooks/use-paginated-items';
 import useWrappedRequest from '@/hooks/use-wrapped-request';
 import {
@@ -31,7 +32,9 @@ const PaginatedSchedules: React.FC<{
     });
 
   return (
-    <>
+    <section className="mx-auto flex flex-col gap-[10px] p-[10px] max-width">
+      <SectionLabel info="Sessions">Courses in Session</SectionLabel>
+
       {paginatedItems?.items.map((schedule, i) => {
         const { days, classType, courseId, name, section, ...rest } = schedule;
         return (
@@ -56,7 +59,7 @@ const PaginatedSchedules: React.FC<{
           {paginatedItems?.items.length !== 0 ? 'Show More' : 'No Schedules ;('}
         </Button>
       ) : null}
-    </>
+    </section>
   );
 };
 

--- a/app/(main)/courses/[id]/@schedules/paginated-schedules.tsx
+++ b/app/(main)/courses/[id]/@schedules/paginated-schedules.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import React from 'react';
+
+import Button from '@/components/button';
+import Schedule from '@/components/schedule/schedule';
+import usePaginatedItems from '@/hooks/use-paginated-items';
+import useWrappedRequest from '@/hooks/use-wrapped-request';
+import { CourseSchedulesRouteParams, CourseSchedulesRouteResponse } from '@/types/api/course/schedules';
+import fakeFetch from '@/utils/fake-fetch';
+
+const PaginatedSchedules: React.FC<{
+  initialPaginatedItems: CourseSchedulesRouteResponse | null;
+  courseId: string;
+}> = ({ initialPaginatedItems, courseId }) => {
+  const initialFetchRequest = (page: number) =>
+    fakeFetch<CourseSchedulesRouteResponse, CourseSchedulesRouteParams>({
+      endpoint: '/course/schedules',
+      params: { itemsPerPage: 4, page: page, id: courseId },
+      timeout: 2000,
+    });
+  const { error, loading, wrappedRequest } = useWrappedRequest();
+  const { isEndOfList, paginatedItems, loadMore } =
+    usePaginatedItems<CourseSchedulesRouteResponse>({
+      initialPaginatedItems,
+      initialFetchRequest: (page: number) =>
+        wrappedRequest(() => initialFetchRequest(page)),
+    });
+
+  return (
+    <>
+      {paginatedItems?.items.map((schedule, i) => {
+        const {
+          days,
+          classType,
+          courseId,
+          name,
+          section,
+          ...rest
+        } = schedule;
+        return (
+          <Schedule
+            key={i}
+            heading={`${name}`}
+            subheading={`Section ${section}`}
+            days={new Set(days)}
+            additionalInfo={[
+              classType,
+            ]}
+            {...rest}
+            section={section}
+          />
+        );
+      })}
+      {!isEndOfList ? (
+        <Button
+          variant="tertiary"
+          disabled={paginatedItems?.items.length === 0}
+          onClick={loadMore}
+          loading={loading}
+        >
+          {paginatedItems?.items.length !== 0 ? 'Show More' : 'No Schedules ;('}
+        </Button>
+      ) : null}
+    </>
+  );
+};
+
+export default PaginatedSchedules;

--- a/app/(main)/courses/[id]/@summary/loading.tsx
+++ b/app/(main)/courses/[id]/@summary/loading.tsx
@@ -6,7 +6,7 @@ import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
 
 export default function Loading() {
   return (
-    <main className="flex flex-col gap-[10px] pb-[10px] opacity-30">
+    <section className="flex flex-col gap-[10px] pb-[10px] opacity-30">
       {/** Breadcrumbs placeholder */}
       <SectionLabelBox className="mb-[10px] mt-[12px] h-[20px] w-[80px] flex-initial animate-pulse rounded-sm bg-neutral p-0" />
 
@@ -105,6 +105,6 @@ export default function Loading() {
           </div>
         </div>
       </div>
-    </main>
+    </section>
   );
 }

--- a/app/(main)/courses/[id]/@summary/page.tsx
+++ b/app/(main)/courses/[id]/@summary/page.tsx
@@ -31,7 +31,11 @@ export default async function Page({
   const courseSummary = await fakeFetch<
     CourseSummaryRouteResponse,
     CourseSummaryRouteParams
-  >({ endpoint: '/course/summary', params: { courseId: params.id}, timeout:1000 });
+  >({
+    endpoint: '/course/summary',
+    params: { courseId: params.id },
+    timeout: 1000,
+  });
 
   if (!courseSummary) notFound();
 

--- a/app/(main)/courses/[id]/@summary/page.tsx
+++ b/app/(main)/courses/[id]/@summary/page.tsx
@@ -31,7 +31,7 @@ export default async function Page({
   const courseSummary = await fakeFetch<
     CourseSummaryRouteResponse,
     CourseSummaryRouteParams
-  >({ endpoint: '/course/summary', params: { courseId: params.id} });
+  >({ endpoint: '/course/summary', params: { courseId: params.id}, timeout:1000 });
 
   if (!courseSummary) notFound();
 

--- a/app/(main)/courses/[id]/@summary/page.tsx
+++ b/app/(main)/courses/[id]/@summary/page.tsx
@@ -31,7 +31,7 @@ export default async function Page({
   const courseSummary = await fakeFetch<
     CourseSummaryRouteResponse,
     CourseSummaryRouteParams
-  >({ endpoint: '/course/summary', params: { id: Number(params.id) } });
+  >({ endpoint: '/course/summary', params: { courseId: params.id} });
 
   if (!courseSummary) notFound();
 

--- a/app/mock-api/course/schedules.ts
+++ b/app/mock-api/course/schedules.ts
@@ -1,0 +1,40 @@
+import {
+  CourseSchedulesRouteParams,
+  CourseSchedulesRouteResponse,
+} from '@/types/api/course/schedules';
+import chooseRandom from '@/utils/choose-random';
+import { FakeResponseFunctionType } from '@/utils/fake-fetch';
+import getPaginatedItems from '@/utils/get-paginated-items';
+
+type CourseSchedule = CourseSchedulesRouteResponse['items'][number];
+const schedules: CourseSchedule[] = Array.from(
+  { length: 30 },
+  (v, k): CourseSchedule => ({
+    name: 'Jahan Ghofraniha',
+    availableSeats: chooseRandom([5, 10, 20]),
+    modeOfInstruction: chooseRandom(['In Person', 'Hybrid', 'Virtual']),
+    classNumber: chooseRandom([23915, 23911, 23040]),
+    classType: chooseRandom(['Lab', 'Lecture']),
+    location: 'ENGR 227',
+    times: '9:00 AM - 10:15 AM',
+    dates: '01/24/24-05/13/24',
+    days: chooseRandom([['M', 'W'], ['T', 'R'], ['R']]),
+    section: chooseRandom(['02', '03', '01', '05', '10']),
+    courseId: chooseRandom(['CMPE130', 'CMPE126']),
+    overall: chooseRandom([1, 2, 3, 4, 5]),
+    grade: chooseRandom(['C', 'C+', 'A', 'B', 'F']),
+  }),
+);
+
+export const response: FakeResponseFunctionType<CourseSchedulesRouteParams> = ({
+  courseId,
+  itemsPerPage,
+  page,
+}): CourseSchedulesRouteResponse =>
+  getPaginatedItems<CourseSchedule>({
+    items: schedules.filter(
+      (schedule) => schedule.courseId?.toLowerCase() === courseId.toLowerCase(),
+    ),
+    itemsPerPage,
+    page,
+  });

--- a/app/mock-api/course/summary.ts
+++ b/app/mock-api/course/summary.ts
@@ -5,7 +5,6 @@ import {
 
 const courses: CourseSummaryRouteResponse[] = [
   {
-    id: 1,
     name: 'Advanced Algorithm Design',
     description:
       'Design and analysis of data structures and algorithms. Advanced tree structures, hashing, searching and sorting. Divide-and-conquer, greedy and dynamic programming algorithm design techniques.',
@@ -31,9 +30,13 @@ const courses: CourseSummaryRouteResponse[] = [
 ];
 
 export const response = ({
-  id,
+  courseId,
 }: CourseSummaryRouteParams): CourseSummaryRouteResponse | null => {
-  const course = courses.find((course) => course.id === id);
+  const course = courses.find(
+    (course) =>
+      (course.department + course.courseNumber).toLowerCase() ===
+      courseId.toLowerCase(),
+  );
   if (!course) {
     return null;
   }

--- a/types/api/course/schedules.ts
+++ b/types/api/course/schedules.ts
@@ -1,0 +1,13 @@
+import { Course, Schedule, User } from '@/types/database';
+import { GenericScheduleType, PaginatedItems } from '@/types/general';
+
+interface CourseSchedule
+  extends GenericScheduleType,
+    Pick<User, 'name'>,
+    Pick<Schedule, 'classType'> {}
+export interface CourseSchedulesRouteParams
+  extends Pick<PaginatedItems<CourseSchedule>, 'itemsPerPage' | 'page'> {
+  courseId: string;
+}
+export interface CourseSchedulesRouteResponse
+  extends PaginatedItems<CourseSchedule> {}

--- a/types/api/course/summary.ts
+++ b/types/api/course/summary.ts
@@ -1,12 +1,13 @@
 import { Course, Review } from '@/types/database';
 import { DistributionType, PercentageType } from '@/types/general';
 
-export interface CourseSummaryRouteParams extends Pick<Course, 'id'> {}
+export interface CourseSummaryRouteParams {
+  courseId: string;
+}
 export interface CourseSummaryRouteResponse
   extends Pick<Review, 'quality' | 'ease' | 'overall' | 'grade' | 'tags'>,
     Pick<
       Course,
-      | 'id'
       | 'name'
       | 'description'
       | 'courseNumber'

--- a/types/database.ts
+++ b/types/database.ts
@@ -41,8 +41,7 @@ export type User = {
 };
 
 export type Course = {
-  id: number;
-  courseNumber: string;  // course number is the 146 in CS146; different from class Number in schedule
+  courseNumber: string; // course number is the 146 in CS146; different from class Number in schedule
   department: Department['abbrDept'];
   createdAt: DateType;
   name: string;


### PR DESCRIPTION
# Frontend Changes
* Add schedules to the courses page
* Add timing for loading sequence so that course summary loads in before course schedules

# Other Changes
* Change courses fetching to fetch by `department+courseNumber` instead of id, which doesn't exist on backend
    * Instead of going to `hosturl/courses/1` to view the courses page, go to `hosturl/courses/cmpe130`
